### PR TITLE
Trying to connect to eventhub and nats server

### DIFF
--- a/alm-location-module/dobi.yaml
+++ b/alm-location-module/dobi.yaml
@@ -51,3 +51,7 @@ job=build-and-push-image-alm-location-module:
   env:
    - DOCKER_DRIVER=overlay2
    - VERSION={env.GitVersion_BranchVersion}
+  annotations:
+    description: "-> builds and pushes alm-location-module multiarch docker images"
+    tags:
+      - build


### PR DESCRIPTION
Tries to connect to `nats` server before continuing.
This is needed, because the startup order and especially the readiness of services for `nats` cannot be foreseen by this service module. 
Therefore it needs to repeat the connect if if failed previously.